### PR TITLE
Improving event handling to accept NumpadEnter

### DIFF
--- a/src/components/Play.tsx
+++ b/src/components/Play.tsx
@@ -84,7 +84,7 @@ export default function Play({
       return;
     }
 
-    if (event.code == "Enter") {
+    if (event.key == "Enter") {
       event.preventDefault();
       const evaluation = evaluateTranslation(
         translation.trim(),

--- a/src/components/Tutorial.tsx
+++ b/src/components/Tutorial.tsx
@@ -32,7 +32,7 @@ export default function Tutorial() {
     event: React.KeyboardEvent<HTMLInputElement>,
     attempt: string,
   ) => {
-    if (event.code == "Enter") {
+    if (event.key == "Enter") {
       event.preventDefault();
 
       if (!attempt.trim()) {


### PR DESCRIPTION
As I was testing css2wind, I notice that `NumpadEnter` doesn't send the answer. I changed the event handling to check if the `key` is `Enter` instead of checking for `code`, which returns `Enter` and `NumpadEnter`, depending of which key is pressed.