### PR TITLE
feat: display correct answer after incorrect attempt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
       },
       "devDependencies": {
         "prettier": "^2.8.8",
-        "prettier-plugin-tailwindcss": "^0.3.0"
+        "prettier-plugin-tailwindcss": "^0.3.0",
+        "tailwindcss-3d": "^1.0.5"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -336,9 +337,13 @@
       "version": "13.4.10",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.10.tgz",
       "integrity": "sha512-4bsdfKmmg7mgFGph0UorD1xWfZ5jZEw4kKRHYEeTK9bT1QnMbPVPlVXQRIiFPrhoDQnZUoa6duuPUJIEGLV1Jg==",
-      "cpu": ["arm64"],
+      "cpu": [
+        "arm64"
+      ],
       "optional": true,
-      "os": ["darwin"],
+      "os": [
+        "darwin"
+      ],
       "engines": {
         "node": ">= 10"
       }
@@ -347,9 +352,13 @@
       "version": "13.4.10",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.10.tgz",
       "integrity": "sha512-ngXhUBbcZIWZWqNbQSNxQrB9T1V+wgfCzAor2olYuo/YpaL6mUYNUEgeBMhr8qwV0ARSgKaOp35lRvB7EmCRBg==",
-      "cpu": ["x64"],
+      "cpu": [
+        "x64"
+      ],
       "optional": true,
-      "os": ["darwin"],
+      "os": [
+        "darwin"
+      ],
       "engines": {
         "node": ">= 10"
       }
@@ -358,9 +367,13 @@
       "version": "13.4.10",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.10.tgz",
       "integrity": "sha512-SjCZZCOmHD4uyM75MVArSAmF5Y+IJSGroPRj2v9/jnBT36SYFTORN8Ag/lhw81W9EeexKY/CUg2e9mdebZOwsg==",
-      "cpu": ["arm64"],
+      "cpu": [
+        "arm64"
+      ],
       "optional": true,
-      "os": ["linux"],
+      "os": [
+        "linux"
+      ],
       "engines": {
         "node": ">= 10"
       }
@@ -369,9 +382,13 @@
       "version": "13.4.10",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.10.tgz",
       "integrity": "sha512-F+VlcWijX5qteoYIOxNiBbNE8ruaWuRlcYyIRK10CugqI/BIeCDzEDyrHIHY8AWwbkTwe6GRHabMdE688Rqq4Q==",
-      "cpu": ["arm64"],
+      "cpu": [
+        "arm64"
+      ],
       "optional": true,
-      "os": ["linux"],
+      "os": [
+        "linux"
+      ],
       "engines": {
         "node": ">= 10"
       }
@@ -380,9 +397,13 @@
       "version": "13.4.10",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.10.tgz",
       "integrity": "sha512-WDv1YtAV07nhfy3i1visr5p/tjiH6CeXp4wX78lzP1jI07t4PnHHG1WEDFOduXh3WT4hG6yN82EQBQHDi7hBrQ==",
-      "cpu": ["x64"],
+      "cpu": [
+        "x64"
+      ],
       "optional": true,
-      "os": ["linux"],
+      "os": [
+        "linux"
+      ],
       "engines": {
         "node": ">= 10"
       }
@@ -391,9 +412,13 @@
       "version": "13.4.10",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.10.tgz",
       "integrity": "sha512-zFkzqc737xr6qoBgDa3AwC7jPQzGLjDlkNmt/ljvQJ/Veri5ECdHjZCUuiTUfVjshNIIpki6FuP0RaQYK9iCRg==",
-      "cpu": ["x64"],
+      "cpu": [
+        "x64"
+      ],
       "optional": true,
-      "os": ["linux"],
+      "os": [
+        "linux"
+      ],
       "engines": {
         "node": ">= 10"
       }
@@ -402,9 +427,13 @@
       "version": "13.4.10",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.10.tgz",
       "integrity": "sha512-IboRS8IWz5mWfnjAdCekkl8s0B7ijpWeDwK2O8CdgZkoCDY0ZQHBSGiJ2KViAG6+BJVfLvcP+a2fh6cdyBr9QQ==",
-      "cpu": ["arm64"],
+      "cpu": [
+        "arm64"
+      ],
       "optional": true,
-      "os": ["win32"],
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": ">= 10"
       }
@@ -413,9 +442,13 @@
       "version": "13.4.10",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.10.tgz",
       "integrity": "sha512-bSA+4j8jY4EEiwD/M2bol4uVEu1lBlgsGdvM+mmBm/BbqofNBfaZ2qwSbwE2OwbAmzNdVJRFRXQZ0dkjopTRaQ==",
-      "cpu": ["ia32"],
+      "cpu": [
+        "ia32"
+      ],
       "optional": true,
-      "os": ["win32"],
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": ">= 10"
       }
@@ -424,9 +457,13 @@
       "version": "13.4.10",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.10.tgz",
       "integrity": "sha512-g2+tU63yTWmcVQKDGY0MV1PjjqgZtwM4rB1oVVi/v0brdZAcrcTV+04agKzWtvWroyFz6IqtT0MoZJA7PNyLVw==",
-      "cpu": ["x64"],
+      "cpu": [
+        "x64"
+      ],
       "optional": true,
-      "os": ["win32"],
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": ">= 10"
       }
@@ -2242,7 +2279,9 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "hasInstallScript": true,
       "optional": true,
-      "os": ["darwin"],
+      "os": [
+        "darwin"
+      ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -3044,6 +3083,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -4529,6 +4574,28 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss-3d": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tailwindcss-3d/-/tailwindcss-3d-1.0.5.tgz",
+      "integrity": "sha512-LWniD56HUGHx1ucvxCfMYe5s23gRsfpTtHtZr+tsWb3kEs4JxRpPFawPegJY4ZlM+O4IMQ9U57e8+QEDFnfiqg==",
+      "dev": true,
+      "dependencies": {
+        "@swc/helpers": "0.5.6",
+        "lodash": "4.17.21"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.2.0"
+      }
+    },
+    "node_modules/tailwindcss-3d/node_modules/@swc/helpers": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.6.tgz",
+      "integrity": "sha512-aYX01Ke9hunpoCexYAgQucEpARGQ5w/cqHFrIR+e9gdKb1QWTsVJuTJ2ozQzIAxLyRQe/m+2RqzkyOOGiMKRQA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "prettier": "^2.8.8",
-    "prettier-plugin-tailwindcss": "^0.3.0"
+    "prettier-plugin-tailwindcss": "^0.3.0",
+    "tailwindcss-3d": "^1.0.5"
   }
 }

--- a/src/components/Play.tsx
+++ b/src/components/Play.tsx
@@ -55,9 +55,6 @@ export default function Play({
   // work around animation transitions for smooth rendering of copy button
   useEffect(() => {
     const hasNotSubmittedScore = score.some((el) => el === "not_submitted");
-    const notSubmittedCount = score.filter(
-      (el) => el === "not_submitted",
-    ).length;
     if (hasNotSubmittedScore) return;
 
     const isLastAnswerCorrect = score.at(-1) === "correct";
@@ -127,7 +124,7 @@ export default function Play({
       }
 
       if (evaluation === "incorrect") {
-        showCorrectAnswer();
+        showCorrectAnswer(800);
         resetInput(2400);
 
         return;

--- a/src/components/Play.tsx
+++ b/src/components/Play.tsx
@@ -3,9 +3,8 @@
 import { useEvaluation } from "@/hooks";
 import { Arrow, Check, Close, Copy } from "@/icons";
 import { getRandomKey } from "@/utils";
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import Scoreboard from "./Scoreboard";
-import autoprefixer from "autoprefixer";
 
 const initialScore = Array(8).fill("not_submitted");
 
@@ -215,7 +214,7 @@ ${emojis}`;
           <span className="hidden tiny:inline">&#125;</span>
         </div>
         {notSubmitted && (
-          <Arrow className="h-6 w-6 rotate-90 fill-zinc-100 md:h-8 md:w-8 lg:rotate-0" />
+          <Arrow className="h-6 w-6 fill-zinc-100 rotate-90 md:h-8 md:w-8 lg:rotate-0" />
         )}
         {correct && (
           <Check className="h-6 w-6 animate-lift fill-greenGo md:h-8 md:w-8" />
@@ -233,13 +232,8 @@ ${emojis}`;
             className="relative w-64 origin-center ring-1 ring-zinc-200 transition-all data-[correct=true]:animate-lift data-[incorrect=true]:animate-shake data-[correct=true]:text-greenGo data-[incorrect=true]:text-alertRed data-[show-correct-answer=true]:text-greenGo data-[correct=true]:ring-greenGo data-[incorrect=true]:ring-alertRed tiny:w-80 sm:w-96 md:w-[420px]"
           >
             <div
-              style={{
-                transformStyle: "preserve-3d",
-                transform: isShowingCorrectAnswer
-                  ? "rotateX(180deg)"
-                  : "rotateX(0deg)",
-              }}
-              className={`relative bg-zinc-950 duration-500`}
+              data-show-correct-answer={isShowingCorrectAnswer}
+              className={`relative bg-zinc-950 duration-500 transform-style-3d data-[show-correct-answer=true]:rotate-x-180`}
             >
               <input
                 id="play-input"
@@ -253,18 +247,11 @@ ${emojis}`;
                 autoCapitalize="off"
                 spellCheck="true"
                 data-not-submitted={notSubmitted}
-                style={{
-                  backfaceVisibility: "hidden",
-                }}
-                className="w-full bg-inherit bg-zinc-950 p-5 text-lg focus:outline-none data-[not-submitted=true]:text-zinc-200 data-[not-submitted=true]:ring-zinc-200 md:text-xl"
+                className="w-full bg-inherit bg-zinc-950 p-5 text-lg backface-hidden focus:outline-none data-[not-submitted=true]:text-zinc-200 data-[not-submitted=true]:ring-zinc-200 md:text-xl"
               />
               <input
                 disabled
-                style={{
-                  backfaceVisibility: "hidden",
-                  transform: "rotateX(180deg)",
-                }}
-                className="absolute inset-0  w-full  bg-inherit bg-zinc-950 p-5 text-lg focus:outline-none  data-[not-submitted=true]:text-zinc-200 data-[not-submitted=true]:ring-zinc-200 md:text-xl"
+                className="absolute inset-0 w-full  bg-inherit  bg-zinc-950 p-5 text-lg rotate-x-180 backface-hidden focus:outline-none  data-[not-submitted=true]:text-zinc-200 data-[not-submitted=true]:ring-zinc-200 md:text-xl"
                 value={correctAnswerToDisplay}
               />
             </div>

--- a/src/hooks/useEvaluation.ts
+++ b/src/hooks/useEvaluation.ts
@@ -5,11 +5,25 @@ type State = {
   correct: boolean;
   incorrect: boolean;
   notSubmitted: boolean;
+  showCorrectAnswer: boolean;
+  correctAnswersList: string[][];
   score: Array<Action["type"]>;
 };
 
-type Action = {
-  type: "correct" | "incorrect" | "not_submitted";
+type Action = BaseAction | CorrectAction | IncorrectAction;
+
+type BaseAction = {
+  type: "not_submitted" | "show_correct_answer";
+};
+
+type CorrectAction = {
+  type: "correct";
+  correctAnswers: string[];
+};
+
+type IncorrectAction = {
+  type: "incorrect";
+  correctAnswers: string[];
 };
 
 function reducer(state: State, action: Action) {
@@ -30,7 +44,12 @@ function reducer(state: State, action: Action) {
         correct: true,
         incorrect: false,
         notSubmitted: false,
+        showCorrectAnswer: false,
         score: updatedScore,
+        correctAnswersList: [
+          ...state.correctAnswersList,
+          action.correctAnswers,
+        ],
       };
     }
     case "incorrect": {
@@ -50,6 +69,11 @@ function reducer(state: State, action: Action) {
         incorrect: true,
         notSubmitted: false,
         score: updatedScore,
+        showCorrectAnswer: false,
+        correctAnswersList: [
+          ...state.correctAnswersList,
+          action.correctAnswers,
+        ],
       };
     }
     case "not_submitted": {
@@ -58,6 +82,15 @@ function reducer(state: State, action: Action) {
         correct: false,
         incorrect: false,
         notSubmitted: true,
+        showCorrectAnswer: false,
+        correctAnswer: "",
+      };
+    }
+
+    case "show_correct_answer": {
+      return {
+        ...state,
+        showCorrectAnswer: true,
       };
     }
   }
@@ -75,12 +108,19 @@ export default function useEvaluation(initialState: State) {
     }
 
     if (dict[cssProperty].includes(attempt)) {
-      dispatch({ type: "correct" });
+      dispatch({
+        type: "correct",
+        correctAnswers: dict[cssProperty],
+      });
+
       return "correct";
     }
 
     if (!dict[cssProperty].includes(attempt)) {
-      dispatch({ type: "incorrect" });
+      dispatch({
+        type: "incorrect",
+        correctAnswers: dict[cssProperty],
+      });
       return "incorrect";
     }
   };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -42,5 +42,5 @@ module.exports = {
       },
     },
   },
-  plugins: [],
+  plugins: [require("tailwindcss-3d")({ legacy: true })],
 };


### PR DESCRIPTION
# Description

This PR aims to add a new feature request on issue #6: to show the correct answer after an incorrect attempt.

My goal was not only to show the correct answer but to have a visual effect so the player could notice the change in the input value. I decided to use a flip on the X-axis, just like this type of clock:

<img src="https://github.com/LukeberryPi/css2wind/assets/74937642/ba805d82-36da-42a1-b95c-361315a8e9ce" height=120px></img>

### The main changes in this PR are:
- 2 new states added to the useEvaluationHook:
  - showCorrectAnswer - this one controls when the input should show the correct answer
  - correctAnswersList - this one stores all previous correct answers. This way we can not only display the last one, but all the correct answers in the end as well, like some sort of summary. 
- 1 new action type to the reducer function to set when to show the correct answer
  - I could have put this in the "incorrect" action type, but I thought it would be better to have it more evident.
- a div wrapper for the inputs that serves as the element that will rotate, while the regular input stays on the front and the input that shows the correct answer is always in the back.
- some validators to check if the correct answer fits inside the input
  - this was needed because some properties have more than 1 possible answer. So, the easy solution I found was to check the length, and if it's bigger than the input can show, only 1 possible answer is shown.
- the `md:top-0` className for the button, because for some reason it was being pushed down.
- the correct answer has the "correct answer" text but the rest of the input is still showing that the attempt was incorrect.
- I changed the end-game verification to use `some` instead of a `filter` with `length` because it reaches the same goal, adding an early return in case the condition is not satisfied.
- the timeout for resetting the input after the correct attempt was kept the same, but it was delayed in case of an incorrect attempt so the user could have time to read the correct answer.
- I added a new tailwind plugin ([recommended in this issue](https://github.com/tailwindlabs/tailwindcss/discussions/3521)) that adds classnames for 3d transformation, which are not supported by default. This plugin allowed me to use every CSS rule I was using via inline CSS before.

### Areas for improvement

I detected some points that, in my opinion, have room for improvement. Some of them are related to my changes but I didn't want to get out of scope:
- The buttons (for submitting the answer and copying the results) could not have an `absolute` className. Instead, they could stay in the document flow and the parent div could resolve this with a `display: flex` rule (some other rules are necessary to achieve the same look, but the main difference comes from the flex display). 
  - This would prevent naturally the input from overflowing into the button when the player tries to type an extensive answer. 
- Name constants outside the component, avoiding the users of magic numbers. Instead of having `resetInput(800)`, it would be `resetInput(TIMEOUT_TO_RESET_INPUT)` and this constant would be declared as `const TIMEOUT_TO_RESET_INPUT=800`
  - This is interesting because the time for resetting the input and setting the game over depends on the time the correct answer is shown, so there would be just 1 place of truth regarding the times.
  - Another example is the `const MAX_INPUT_LENGTH = 23` that could be added instead of just having `>= 23` in the code.
The end-game detection doesn't need to be inside an `useEffect`. It could be directly in the code and I believe the current behavior could lead to unwanted behavior, since `useEffect` runs after the HTML is painted with the new states.
- The input and button could be part of a `form`, so the "Enter" would automatically be used for submitting the enter and it wouldn't need 2 functions to do the same thing (`handleReturnClick` and `handleKeyDown`).
- Call side effects directly. Instead of the `setTimeout` being inside the `resetInput` function, it could be better to make this function pure on what it does and have the setTimeout only when it gets called. This makes controlling the side effects easier. Even the end-game validation could be called directly after an evaluation since the game can only end after an attempt was made.
- The last one would be turning specific parts of the code into components. The logic for showing the correct answer would fit much better inside some sort of `AnswerInput` separate component instead of being loose in the `Play` component.

Issue: https://github.com/LukeberryPi/css2wind/issues/6

# Screenshots and Videos

### Big screen:
![X0q3t1soNR](https://github.com/LukeberryPi/css2wind/assets/74937642/314a4dc0-a688-4113-b015-5337b25382a9)

### Medium screen:
![ol0LRGLOed](https://github.com/LukeberryPi/css2wind/assets/74937642/85172abb-5384-4a14-b7f8-4798fd70262e)

### Small screen:
![VKJV8In3hf](https://github.com/LukeberryPi/css2wind/assets/74937642/5e66d0be-6ac7-4a55-8c7c-6ed768b15cf0)

### Correct answer (faster input reset, nothing changes):

![ANCgXWZELd](https://github.com/LukeberryPi/css2wind/assets/74937642/da91f8c6-e833-4218-a5f3-502fe84debe0)

### Game-end:

![kcqzpJShjf](https://github.com/LukeberryPi/css2wind/assets/74937642/6816d206-2fdc-464a-88bd-f97580b30921)
